### PR TITLE
Async and Failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Danny Browning <danny.browning@protectwise.com>"]
 edition = "2018"
 
 [dependencies]
+bincode = "~1.0"
 crossbeam-channel = "~0.3"
-error-chain = "~0.12"
-futures = "~0.1"
+failure = "~0.1"
+failure_derive = "~0.1"
+futures-preview = { version ="0.3.0-alpha.11", features = ["compat"] }
 ipc-channel = "~0.11"
 log = "~0.4"
 serde = "~1.0"
@@ -15,4 +17,4 @@ serde_derive = "~1.0"
 serde_json = "~1.0"
 
 [dev-dependencies]
-env_logger = "*"
+env_logger = "~0.6"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,18 @@
+use failure::Fail;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "IO Error")]
+    Io(#[fail(cause)] std::io::Error),
+    #[fail(display = "Null pointer when dealing with ffi")]
+    Ffi(#[fail(cause)] std::ffi::NulError),
+    #[fail(display = "Utf8 conversion error")]
+    Utf8(#[fail(cause)] std::str::Utf8Error),
+    #[fail(display = "Error during bincode")]
+    Bincode(#[fail(cause)] bincode::Error),
+    #[fail(display = "Error receiving")]
+    Recv(#[fail(cause)] crossbeam_channel::RecvError),
+}
+
+unsafe impl Sync for Error {}
+unsafe impl Send for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,6 @@
-#[macro_use] extern crate error_chain;
-
-pub mod errors {
-    use std;
-
-    // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain! {
-        foreign_links {
-            Io(std::io::Error) #[doc = "Error during IO"];
-            Ffi(std::ffi::NulError) #[doc = "Error during FFI conversion"];
-            Utf8(std::str::Utf8Error) #[doc = "Error during UTF8 conversion"];
-            ChannelCancelled(futures::sync::oneshot::Canceled) #[doc = "Channel was cancelled"];
-            ChannelReceive(crossbeam_channel::RecvError) #[doc = "Error during receive"];
-        }
-        errors {
-            ChannelError {
-                display("Channel encountered an error")
-            }
-            ConnectionFailed {
-                display("Failed to form connection")
-            }
-            IpcFailure {
-                display("IPC Failure")
-            }
-            Bincode {
-                display("Bincode failure")
-            }
-        }
-    }
-}
+#![feature(futures_api, async_await, await_macro)]
 
 pub mod client;
+pub mod errors;
 pub mod packet;
 pub mod server;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,23 +1,25 @@
-use ipc_channel::{
-    ipc::IpcSharedMemory
-};
-use serde_derive::{Serialize, Deserialize};
+use ipc_channel::ipc::IpcSharedMemory;
+use serde_derive::{Deserialize, Serialize};
 
 #[repr(C)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Packet {
     ts: std::time::SystemTime,
-    data: IpcSharedMemory
+    data: IpcSharedMemory,
 }
 
 impl Packet {
-    pub fn timestamp(&self) -> &std::time::SystemTime { &self.ts }
-    pub fn data(&self) -> &[u8] { &self.data }
+    pub fn timestamp(&self) -> &std::time::SystemTime {
+        &self.ts
+    }
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
 
     pub fn new<T: AsRef<[u8]>>(ts: std::time::SystemTime, data: T) -> Packet {
         Packet {
             ts: ts,
-            data: IpcSharedMemory::from_bytes(data.as_ref())
+            data: IpcSharedMemory::from_bytes(data.as_ref()),
         }
     }
 
@@ -25,42 +27,39 @@ impl Packet {
         if ptr == std::ptr::null() {
             panic!("Passed a null pointer to Packet::new");
         }
-        let s = unsafe {
-            std::slice::from_raw_parts(ptr, len)
-        };
+        let s = unsafe { std::slice::from_raw_parts(ptr, len) };
         Packet {
             ts: ts,
-            data: IpcSharedMemory::from_bytes(s)
+            data: IpcSharedMemory::from_bytes(s),
         }
     }
 
-    pub fn into_mut_ptr(self) -> *mut Packet {
-        Box::into_raw(Box::new(self))
+    pub fn into_raw(mut self) -> *mut Packet {
+        let s_ptr = &mut self as *mut Packet;
+        std::mem::forget(self); //this will leak memory, you will need to eventually call Packet::from_raw to release it
+        s_ptr
     }
 
-    pub fn from_raw(p: *mut Packet) -> Box<Packet> {
-        unsafe {
-            Box::from_raw(p)
-        }
+    pub fn from_raw(p: *mut Packet) -> Option<Packet> {
+        let opt_packet_ref = unsafe { p.as_mut() };
+        opt_packet_ref.map(|r| {
+            let init_packet = std::mem::replace(r, unsafe { std::mem::uninitialized() });
+            std::mem::forget(r);
+            init_packet
+        })
     }
 }
 
-impl Drop for Packet {
-    fn drop(&mut self) {
-        println!("Drop occurred");
+impl Default for Packet {
+    fn default() -> Self {
+        Packet {
+            ts: std::time::SystemTime::UNIX_EPOCH,
+            data: IpcSharedMemory::from_byte(0, 0),
+        }
     }
 }
 
 unsafe impl Send for Packet {}
-
-pub trait AsIpcPacket {
-    fn timestamp(&self) -> &std::time::SystemTime;
-    fn data(&self) -> &[u8];
-
-    fn as_ipc_packet(&self) -> Packet {
-        Packet::new(self.timestamp().clone(), self.data())
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -68,8 +67,8 @@ mod tests {
     #[test]
     fn test_into_raw() {
         let packet = Packet::new(std::time::UNIX_EPOCH, vec![0u8, 1u8, 2u8, 3u8]);
-        let raw = packet.into_mut_ptr();
-        let rt = Packet::from_raw(raw);
+        let raw = packet.into_raw();
+        let rt = Packet::from_raw(raw).expect("No packet");
 
         assert_eq!(rt.data(), &[0u8, 1u8, 2u8, 3u8]);
     }


### PR DESCRIPTION
Use async/await, futures 0.3, and failure (since error-chain is deprecated).

Other Improvements
* Boxing of packets no longer required
* AsIpcPacket no longer needed
* Server is now just a sink