### PR TITLE
Fix non-public methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 # When releasing to crates.io:
 # - Update doc URL.
 # - Create "vX.Y.Z" git tag.
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT"
 readme = "README.md"
 description = """

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Client {
         })
     }
 
-    fn take(&mut self, size: usize) -> IpcMessage {
+    pub fn take(&mut self, size: usize) -> IpcMessage {
         let packets_to_take = usize::min(size, self.available.len());
         let mut rem = self.available.split_off(packets_to_take);
         std::mem::swap(&mut self.available, &mut rem);

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,21 +33,19 @@ impl Server {
     }
 }
 
-#[allow(dead_code)]
 pub struct ConnectedIpc {
     connection: IpcSender<Option<IpcMessage>>,
 }
 
-#[allow(dead_code)]
 impl ConnectedIpc {
-    fn send(&mut self, v: IpcMessage) -> Result<(), Error> {
+    pub fn send(&mut self, v: IpcMessage) -> Result<(), Error> {
         self.connection.send(Some(v)).map_err(|e| {
             error!("Failed to send {:?}", e);
             Error::Bincode(e)
         })
     }
 
-    fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<(), Error> {
         self.connection.send(None).map_err(Error::Bincode)?;
         Ok(())
     }


### PR DESCRIPTION
In removal of async functionality, some required methods were not public