### PR TITLE
Don't block the thread calling send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/packet-ipc/"
 repository = "https://github.com/protectwise/packet-ipc"
 
 [dependencies]
+blocking = "0.5"
 bincode = "1"
 crossbeam-channel = "0.3"
 ipc-channel = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ thiserror = "1"
 
 [dev-dependencies]
 env_logger = "0.7"
+tokio-test = "0.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Bincode(#[from] bincode::Error),
     #[error("Error receiving: {0:?}")]
     Recv(#[from] crossbeam_channel::RecvError),
+    #[error("Mutex was poisoned")]
+    Mutex(),
 }
 
 unsafe impl Sync for Error {}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -2,18 +2,18 @@ use serde::{Deserialize, Serialize};
 
 pub trait AsIpcPacket {
     fn timestamp(&self) -> &std::time::SystemTime;
-    fn data(&self) -> &[u8];
+    fn data(&self) -> Vec<u8>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct IpcPacket<'a> {
+pub struct IpcPacket {
     timestamp: std::time::SystemTime,
     #[serde(with = "serde_bytes")]
-    data: &'a [u8],
+    data: Vec<u8>,
 }
 
-impl<'a, T: AsIpcPacket> From<&'a T> for IpcPacket<'a> {
-    fn from(v: &'a T) -> Self {
+impl<T: AsIpcPacket> From<&T> for IpcPacket {
+    fn from(v: &T) -> Self {
         IpcPacket {
             timestamp: v.timestamp().clone(),
             data: v.data(),
@@ -21,8 +21,8 @@ impl<'a, T: AsIpcPacket> From<&'a T> for IpcPacket<'a> {
     }
 }
 
-impl<'a> From<IpcPacket<'a>> for Packet {
-    fn from(v: IpcPacket<'a>) -> Self {
+impl From<IpcPacket> for Packet {
+    fn from(v: IpcPacket) -> Self {
         Packet {
             ts: v.timestamp.clone(),
             data: v.data.to_vec(),
@@ -50,8 +50,8 @@ impl AsIpcPacket for Packet {
     fn timestamp(&self) -> &std::time::SystemTime {
         &self.ts
     }
-    fn data(&self) -> &[u8] {
-        self.data.as_ref()
+    fn data(&self) -> Vec<u8> {
+        self.data.clone()
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use crate::errors::Error;
 use crate::packet::{AsIpcPacket, IpcPacket};
 use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 use log::*;
+use std::sync::{Arc, Mutex};
 
 pub type SenderMessage = Option<Vec<IpcPacket>>;
 pub type Sender = IpcSender<SenderMessage>;
@@ -31,25 +32,40 @@ impl Server {
 
         info!("Accepted connection from {:?}", tx);
 
+        let tx = Arc::new(Mutex::new(tx));
+
         Ok(ConnectedIpc { connection: tx })
     }
 }
 
+
 pub struct ConnectedIpc {
-    connection: Sender,
+    connection: Arc<Mutex<Sender>>,
 }
 
 impl ConnectedIpc {
-    pub fn send<T: AsIpcPacket>(&self, packets: Vec<T>) -> Result<(), Error> {
+    pub async fn send<T: AsIpcPacket>(&self, packets:Vec<T>) -> Result<(), Error> {
         let ipc_packets: Vec<_> = packets.iter().map(IpcPacket::from).collect();
-        self.connection.send(Some(ipc_packets)).map_err(|e| {
-            error!("Failed to send {:?}", e);
-            Error::Bincode(e)
-        })
+        Self::internal_send(Arc::clone(&self.connection), ipc_packets).await
+    }
+
+    async fn internal_send(sender: Arc<Mutex<Sender>>, ipc_packets: Vec<IpcPacket>) -> Result<(), Error> {
+        blocking::Unblock::new(()).with_mut(move |_| {
+            let sender = Arc::clone(&sender);
+            let sender = sender.lock().map_err(|_| Error::Mutex())?;
+            sender.send(Some(ipc_packets)).map_err(|e| {
+                error!("Failed to send {:?}", e);
+                Error::Bincode(e)
+            });
+            Ok(())
+        }).await
+
     }
 
     pub fn close(&mut self) -> Result<(), Error> {
-        self.connection.send(None).map_err(Error::Bincode)?;
+        let connection = Arc::clone(&self.connection);
+        let connection = connection.lock().map_err(|_| Error::Mutex())?;
+        connection.send(None).map_err(Error::Bincode)?;
         Ok(())
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,8 +56,7 @@ impl ConnectedIpc {
             sender.send(Some(ipc_packets)).map_err(|e| {
                 error!("Failed to send {:?}", e);
                 Error::Bincode(e)
-            });
-            Ok(())
+            })
         }).await
 
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,5 @@
 use packet_ipc::{AsIpcPacket, Client, Error, IpcPacket, Packet, Server};
+use tokio_test::block_on;
 
 #[test]
 fn test_roundtrip() {
@@ -45,9 +46,9 @@ fn test_packet_receive() {
     });
 
     let mut server_tx = server.accept().expect("Failed to accept connection");
-
+    block_on(
     server_tx
-        .send(&vec![Packet::new(std::time::SystemTime::now(), vec![3u8])])
+        .send(vec![Packet::new(std::time::SystemTime::now(), vec![3u8])]))
         .expect("Failed to send");
 
     server_tx.close().expect("Failed to close");
@@ -86,11 +87,11 @@ fn test_multiple_packet_receive() {
 
     let mut server_tx = server.accept().expect("Failed to accept connection");
 
-    server_tx
-        .send(&vec![Packet::new(std::time::SystemTime::now(), vec![3u8])])
+    block_on(server_tx
+        .send(vec![Packet::new(std::time::SystemTime::now(), vec![3u8])]))
         .expect("Failed to send");
-    server_tx
-        .send(&vec![Packet::new(std::time::SystemTime::now(), vec![4u8])])
+    block_on(server_tx
+        .send(vec![Packet::new(std::time::SystemTime::now(), vec![4u8])]))
         .expect("Failed to send");
 
     server_tx.close().expect("Failed to close");


### PR DESCRIPTION
Idea is to run an internal pool of threads so that blocking operations don't block the callers... is this a good idea?

Many changes here, some maybe not so good. 
* For one the life times have been removed, everything is now owned. This may mean additional copies for implementors. The reason for the lifetime removal was to allow for the data to be shuttled off to a different thread, and since we enforce 'a life time on the data and the Sender it maybe it difficult to refactor code that used this lib, if we wanted to run in a seperate pool.
* We add a mutex on the sender, internally ConnectedServer uses a Cell which is not thread safe, so we threw a mutex around it... EZ.

I am pushing these, since they may be interesting, but I am not sold that this is hte best way forward.